### PR TITLE
Enable Windows self-test on all versions of Python

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 name: Main workflow
-on: [push]
+on: [push, pull_request]
 jobs:
   run:
     name: Run

--- a/selftest.nox.py
+++ b/selftest.nox.py
@@ -6,7 +6,7 @@ nox.options.error_on_external_run = True
 
 pythons = {
     'linux': ['2.7', '3.5', '3.6', '3.7', 'pypy', 'pypy3'],
-    'win32': ['3.5', '3.6', '3.7'],
+    'win32': ['2.7', '3.5', '3.6', '3.7', 'pypy', 'pypy3'],
     'darwin': ['2.7', '3.5', '3.6', '3.7', 'pypy', 'pypy3'],
 }[sys.platform]
 


### PR DESCRIPTION
I wanna know... why does Windows fail?

Mostly because I'd like to run this w/ Python 2 (i know, it's sad) and PyPy as well; on all platforms.