### PR TITLE
Update README example to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Basic:
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: excitedleigh/setup-nox@v2.0.0
+  - uses: excitedleigh/setup-nox@v2.1.0
   - run: nox
 ```
 


### PR DESCRIPTION
I copy/pasted the example in the README, but this resulted in a confusing GitHub Workflows error. When I updated to the latest released version of this repository, it worked, so this updates the README example as well!