### PR TITLE
🔧 Update Action to `Node16`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: 'copy'
   color: 'green'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub is deprecating actions running with `Node12`. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Every run that currently uses this action receives warnings like

> **Warning**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: excitedleigh/setup-nox

This PR updates the underlying node version to 16. In the best case, no further changes are required.