### PR TITLE
Try to install nox with the latest available (non-prerelease) version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This action sets up a Python environment with Nox by:
 - Activating every version of Python that GitHub Actions supports.
 - Installing Nox.
 
-After you use it, you'll be able to use Nox with [every Python version available on GitHub Actions][actions-installed]. Nox itself will be installed in the newest available Python version.
+After you use it, you'll be able to use Nox with [every Python version available on GitHub Actions][actions-installed]. Nox itself will be installed in the newest available (non-prerelease) Python version.
 
 This action runs in the GitHub Actions environment itself and not in Docker, which means it works on Linux, Windows and macOS, but only with the available Python versions. If you need Python versions outside that, but you only need Linux, you can also try the [thekevjames/nox Docker images][nox-docker].
 

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -2,6 +2,7 @@ import { findAllVersions, find as findVersion } from "@actions/tool-cache"
 import { addPath } from "@actions/core"
 import { execSync } from "child_process"
 import { symlinkSync, readdirSync, readdir, existsSync } from "fs"
+import { maxSatisfying, valid } from "semver"
 
 //function installPythonVersion(type: "Python" | "PyPy")
 
@@ -40,7 +41,9 @@ for (const version of allCPythonVersions) {
   }
 }
 
-const NOX_PYTHON_VERSION = allCPythonVersions[allCPythonVersions.length - 1]
+const NOX_PYTHON_VERSION =
+    maxSatisfying(allCPythonVersions.filter(valid), `*`) ||
+    allCPythonVersions[allCPythonVersions.length - 1]
 console.log("Nox itself will be installed using", NOX_PYTHON_VERSION)
 const NOX_PYTHON_PATH =
   findVersion("Python", NOX_PYTHON_VERSION) +


### PR DESCRIPTION
`@actions/tool-cache` has `evaluateVersions` which could be used, but it barfs on invalid semvers, so we need to pre-filter available versions with `semver.valid` anyway.

Just use `semver.maxSatisfying` while at it. Let `@actions/tool-cache` bring in the `semver` dep it works with. Fall back to the old behavior in case none of the versions are valid semvers.

Closes https://github.com/daisylb/setup-nox/issues/431